### PR TITLE
Add postcode-based address lookup to Add Property form

### DIFF
--- a/templates/add_property.html
+++ b/templates/add_property.html
@@ -26,9 +26,49 @@
       </select>
     </div>
     <div class="form-group">
+      <label for="postcode">Postcode</label>
+      <input type="text" id="postcode" placeholder="Enter postcode" />
+    </div>
+    <div class="form-group">
       <label for="address">Address</label>
-      <input type="text" id="address" name="address" />
+      <select id="address" name="address">
+        <option value="">Select an address</option>
+      </select>
     </div>
     <button type="submit" class="btn">Add Property</button>
   </form>
+  <script>
+    const GET_ADDRESS_API_KEY = "PASTE_YOUR_API_KEY_HERE"; // Replace with your API key
+    document
+      .getElementById("postcode")
+      .addEventListener("change", async function () {
+        const postcode = this.value.trim();
+        const addressSelect = document.getElementById("address");
+        addressSelect.innerHTML = '<option value="">Loading...</option>';
+        if (!postcode) {
+          addressSelect.innerHTML = '<option value="">Select an address</option>';
+          return;
+        }
+        try {
+          const response = await fetch(
+            `https://api.getAddress.io/find/${encodeURIComponent(
+              postcode
+            )}?api-key=${GET_ADDRESS_API_KEY}`
+          );
+          if (!response.ok) {
+            throw new Error("Lookup failed");
+          }
+          const data = await response.json();
+          addressSelect.innerHTML = "";
+          data.addresses.forEach((addr) => {
+            const option = document.createElement("option");
+            option.value = addr;
+            option.textContent = addr;
+            addressSelect.appendChild(option);
+          });
+        } catch (err) {
+          addressSelect.innerHTML = '<option value="">No addresses found</option>';
+        }
+      });
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add postcode input and address dropdown to Add Property form
- fetch addresses via getAddress.io API; placeholder shows where to insert API key

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f336871b48330bef37265bf3cda11