### PR TITLE
Organize property form into collapsible sections with persistent actions

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -137,6 +137,47 @@ body {
   display: grid;
   gap: 1rem;
   max-width: 600px;
+  padding-bottom: 6rem;
+}
+
+.form-section {
+  background-color: #ffffff;
+  border: 1px solid #d1d9e6;
+  border-radius: 4px;
+  padding: 1rem;
+}
+
+.form-section + .form-section {
+  margin-top: 1rem;
+}
+
+.form-section summary {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #2c3e50;
+  cursor: pointer;
+  margin-bottom: 1rem;
+}
+
+.form-actions {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background-color: #ffffff;
+  border-top: 1px solid #d1d9e6;
+  padding: 1rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.btn-secondary {
+  background-color: #95a5a6;
+}
+
+.btn-secondary:hover {
+  background-color: #7f8c8d;
 }
 
 .form-group {

--- a/templates/add_property.html
+++ b/templates/add_property.html
@@ -3,135 +3,147 @@
 {% block content %}
   <h1 class="page-title">Add New Property</h1>
   <form method="post" class="form" id="property_form">
-    <div class="form-group">
-      <label for="postcode">Postcode</label>
-      <input
-        type="text"
-        id="postcode"
-        name="postcode"
-        placeholder="Enter postcode"
-        required
-      />
-    </div>
-    <div class="form-group">
-      <label for="address">Address</label>
-      <select id="address" name="address" required>
-        <option value="">Select an address</option>
-      </select>
-    </div>
-    <div class="form-group">
-      <label for="name">Name</label>
-      <input type="text" id="name" name="name" required />
-    </div>
-    <div class="form-group">
-      <label for="purchase_price">Purchase price (£)</label>
-      <input
-        type="number"
-        id="purchase_price"
-        name="purchase_price"
-        step="0.01"
-        min="0"
-        required
-      />
-    </div>
-    <div class="form-group">
-      <label for="acquisition_date">Acquisition date</label>
-      <input type="date" id="acquisition_date" name="acquisition_date" required />
-    </div>
-    <div class="form-group">
-      <label for="type">Type</label>
-      <select id="type" name="type" required>
-        <option value="personal">Personal</option>
-        <option value="company">Company</option>
-      </select>
-    </div>
-    <h2 class="section-title">Lease</h2>
-    <div class="form-group">
-      <label for="lease_type">Lease type</label>
-      <select id="lease_type" name="lease_type" required>
-        <option value="council_20">Council 20 Year</option>
-        <option value="council_7">Council 7 Year</option>
-        <option value="ast">AST</option>
-        <option value="hmo">HMO</option>
-      </select>
-    </div>
-    <div class="form-group">
-      <label for="rent_input_type">Monthly rent input</label>
-      <select id="rent_input_type">
-        <option value="currency">£</option>
-        <option value="percent">%</option>
-      </select>
-    </div>
-    <div class="form-group" id="rent_percent_group" style="display: none;">
-      <label for="monthly_rent_percent">Monthly rent (%)</label>
-      <input type="number" id="monthly_rent_percent" step="0.01" min="0" />
-    </div>
-    <div class="form-group">
-      <label for="monthly_rent">Monthly rent (£)</label>
-      <input
-        type="number"
-        id="monthly_rent"
-        name="monthly_rent"
-        step="0.01"
-        min="0"
-        required
-      />
-    </div>
-    <div class="form-group">
-      <label for="indexation_type">Indexation type</label>
-      <select id="indexation_type" name="indexation_type">
-        <option value="none">None</option>
-        <option value="fixed">Fixed</option>
-        <option value="cpi">CPI</option>
-      </select>
-    </div>
-    <div class="form-group">
-      <label for="indexation_rate">Indexation rate (%)</label>
-      <input type="number" id="indexation_rate" name="indexation_rate" step="0.01" min="0" />
-    </div>
-    <div class="form-group">
-      <label for="lease_start">Lease start date</label>
-      <input type="date" id="lease_start" name="lease_start" />
-    </div>
-    <div class="form-group">
-      <label for="lease_end">Lease end date</label>
-      <input type="date" id="lease_end" name="lease_end" />
-    </div>
-
-    <h2 class="section-title">Mortgage</h2>
-    <div class="form-group">
-      <label for="has_mortgage">Has mortgage?</label>
-      <select id="has_mortgage" name="has_mortgage">
-        <option value="no">No</option>
-        <option value="yes">Yes</option>
-      </select>
-    </div>
-    <div id="mortgage_fields" style="display: none; gap: 1rem;">
+    <details class="form-section" open>
+      <summary>Property Details</summary>
       <div class="form-group">
-        <label for="lender_name">Lender name</label>
-        <input type="text" id="lender_name" name="lender_name" />
+        <label for="postcode">Postcode</label>
+        <input
+          type="text"
+          id="postcode"
+          name="postcode"
+          placeholder="Enter postcode"
+          required
+        />
       </div>
       <div class="form-group">
-        <label for="loan_amount">Loan amount (£)</label>
-        <input type="number" id="loan_amount" name="loan_amount" step="0.01" min="0" />
-      </div>
-      <div class="form-group">
-        <label for="interest_rate">Interest rate (%)</label>
-        <input type="number" id="interest_rate" name="interest_rate" step="0.01" min="0" />
-      </div>
-      <div class="form-group">
-        <label for="repayment_type">Repayment type</label>
-        <select id="repayment_type" name="repayment_type">
-          <option value="interest_only">Interest-only</option>
-          <option value="repayment">Repayment</option>
+        <label for="address">Address</label>
+        <select id="address" name="address" required>
+          <option value="">Select an address</option>
         </select>
       </div>
       <div class="form-group">
-        <label for="mortgage_term">Term (years)</label>
-        <input type="number" id="mortgage_term" name="mortgage_term" min="0" />
+        <label for="name">Name</label>
+        <input type="text" id="name" name="name" required />
       </div>
+      <div class="form-group">
+        <label for="purchase_price">Purchase price (£)</label>
+        <input
+          type="number"
+          id="purchase_price"
+          name="purchase_price"
+          step="0.01"
+          min="0"
+          required
+        />
+      </div>
+      <div class="form-group">
+        <label for="acquisition_date">Acquisition date</label>
+        <input type="date" id="acquisition_date" name="acquisition_date" required />
+      </div>
+      <div class="form-group">
+        <label for="type">Type</label>
+        <select id="type" name="type" required>
+          <option value="personal">Personal</option>
+          <option value="company">Company</option>
+        </select>
+      </div>
+    </details>
+
+    <details class="form-section">
+      <summary>Lease Details</summary>
+      <div class="form-group">
+        <label for="lease_type">Lease type</label>
+        <select id="lease_type" name="lease_type" required>
+          <option value="council_20">Council 20 Year</option>
+          <option value="council_7">Council 7 Year</option>
+          <option value="ast">AST</option>
+          <option value="hmo">HMO</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="rent_input_type">Monthly rent input</label>
+        <select id="rent_input_type">
+          <option value="currency">£</option>
+          <option value="percent">%</option>
+        </select>
+      </div>
+      <div class="form-group" id="rent_percent_group" style="display: none;">
+        <label for="monthly_rent_percent">Monthly rent (%)</label>
+        <input type="number" id="monthly_rent_percent" step="0.01" min="0" />
+      </div>
+      <div class="form-group">
+        <label for="monthly_rent">Monthly rent (£)</label>
+        <input
+          type="number"
+          id="monthly_rent"
+          name="monthly_rent"
+          step="0.01"
+          min="0"
+          required
+        />
+      </div>
+      <div class="form-group">
+        <label for="indexation_type">Indexation type</label>
+        <select id="indexation_type" name="indexation_type">
+          <option value="none">None</option>
+          <option value="fixed">Fixed</option>
+          <option value="cpi">CPI</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="indexation_rate">Indexation rate (%)</label>
+        <input type="number" id="indexation_rate" name="indexation_rate" step="0.01" min="0" />
+      </div>
+      <div class="form-group">
+        <label for="lease_start">Lease start date</label>
+        <input type="date" id="lease_start" name="lease_start" />
+      </div>
+      <div class="form-group">
+        <label for="lease_end">Lease end date</label>
+        <input type="date" id="lease_end" name="lease_end" />
+      </div>
+    </details>
+
+    <details class="form-section">
+      <summary>Mortgage Details</summary>
+      <div class="form-group">
+        <label for="has_mortgage">Has mortgage?</label>
+        <select id="has_mortgage" name="has_mortgage">
+          <option value="no">No</option>
+          <option value="yes">Yes</option>
+        </select>
+      </div>
+      <div id="mortgage_fields" style="display: none; gap: 1rem;">
+        <div class="form-group">
+          <label for="lender_name">Lender name</label>
+          <input type="text" id="lender_name" name="lender_name" />
+        </div>
+        <div class="form-group">
+          <label for="loan_amount">Loan amount (£)</label>
+          <input type="number" id="loan_amount" name="loan_amount" step="0.01" min="0" />
+        </div>
+        <div class="form-group">
+          <label for="interest_rate">Interest rate (%)</label>
+          <input type="number" id="interest_rate" name="interest_rate" step="0.01" min="0" />
+        </div>
+        <div class="form-group">
+          <label for="repayment_type">Repayment type</label>
+          <select id="repayment_type" name="repayment_type">
+            <option value="interest_only">Interest-only</option>
+            <option value="repayment">Repayment</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="mortgage_term">Term (years)</label>
+          <input type="number" id="mortgage_term" name="mortgage_term" min="0" />
+        </div>
+      </div>
+    </details>
+
+    <div class="form-actions">
+      <a href="/properties" class="btn btn-secondary">Cancel</a>
+      <button type="submit" class="btn">Save Property</button>
     </div>
-    <button type="submit" class="btn">Add Property</button>
   </form>
   <script>
     const GET_ADDRESS_API_KEY = "MR3OmMfdukGPgl0gW_Ztxw44533"; // Replace with your API key


### PR DESCRIPTION
## Summary
- Group add-property fields into collapsible panels for property, lease, and mortgage details
- Keep save button fixed to bottom of viewport and add cancel button linking back to properties list
- Style new sections and action bar

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f3f044bf08330bdf3e617d1cd4336