### PR TITLE
Add edit and delete actions for properties

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -23,6 +23,33 @@ def create_property(db: Session, property_in: schemas.PropertyCreate):
     return db_property
 
 
+def get_property(db: Session, property_id: int):
+    """Retrieve a single property by its ID."""
+    return db.query(models.Property).filter(models.Property.id == property_id).first()
+
+
+def update_property(db: Session, property_id: int, property_in: schemas.PropertyCreate):
+    """Update an existing property with new data."""
+    db_property = get_property(db, property_id)
+    if db_property:
+        db_property.name = property_in.name
+        db_property.value = property_in.value
+        db_property.type = property_in.type
+        db_property.address = property_in.address
+        db.commit()
+        db.refresh(db_property)
+    return db_property
+
+
+def delete_property(db: Session, property_id: int):
+    """Delete a property from the database."""
+    db_property = get_property(db, property_id)
+    if db_property:
+        db.delete(db_property)
+        db.commit()
+    return db_property
+
+
 def portfolio_summary(db: Session):
     """Compute summary statistics for the dashboard."""
     personal_count = (

--- a/app/main.py
+++ b/app/main.py
@@ -83,6 +83,42 @@ def add_property(
     return RedirectResponse(url="/properties", status_code=303)
 
 
+@app.get("/properties/{property_id}/edit", response_class=HTMLResponse)
+def edit_property_form(property_id: int, request: Request, db: Session = Depends(get_db)):
+    """Render a form pre-populated with an existing property's data."""
+    property_obj = crud.get_property(db, property_id)
+    if not property_obj:
+        return RedirectResponse(url="/properties", status_code=303)
+    return templates.TemplateResponse(
+        "edit_property.html", {"request": request, "property": property_obj}
+    )
+
+
+@app.post("/properties/{property_id}/edit")
+def update_property(
+    property_id: int,
+    request: Request,
+    name: str = Form(...),
+    value: float = Form(...),
+    type: str = Form(...),
+    address: str = Form(""),
+    db: Session = Depends(get_db),
+):
+    """Update an existing property and redirect to the list."""
+    property_in = schemas.PropertyCreate(
+        name=name, value=value, type=schemas.PropertyType(type), address=address
+    )
+    crud.update_property(db, property_id, property_in)
+    return RedirectResponse(url="/properties", status_code=303)
+
+
+@app.post("/properties/{property_id}/delete")
+def delete_property(property_id: int, db: Session = Depends(get_db)):
+    """Delete a property and redirect to the list."""
+    crud.delete_property(db, property_id)
+    return RedirectResponse(url="/properties", status_code=303)
+
+
 # Include placeholder routers for future functionality.
 app.include_router(refinancing.router)
 app.include_router(acquisition.router)

--- a/templates/edit_property.html
+++ b/templates/edit_property.html
@@ -1,0 +1,30 @@
+{% extends "layout.html" %}
+{% block title %}Edit Property – Property Planner{% endblock %}
+{% block content %}
+  <h1 class="page-title">Edit Property</h1>
+  <form method="post" class="form">
+    <div class="form-group">
+      <label for="name">Name</label>
+      <input type="text" id="name" name="name" value="{{ property.name }}" required />
+    </div>
+    <div class="form-group">
+      <label for="value">Value (£)</label>
+      <input type="number" id="value" name="value" step="0.01" min="0" value="{{ property.value }}" required />
+    </div>
+    <div class="form-group">
+      <label for="type">Type</label>
+      <select id="type" name="type" required>
+        <option value="personal" {% if property.type.value == 'personal' %}selected{% endif %}>Personal</option>
+        <option value="company" {% if property.type.value == 'company' %}selected{% endif %}>Company</option>
+      </select>
+    </div>
+    <div class="form-group">
+      <label for="address">Address</label>
+      <input type="text" id="address" name="address" value="{{ property.address }}" />
+    </div>
+    <div class="form-actions">
+      <a href="/properties" class="btn btn-secondary">Cancel</a>
+      <button type="submit" class="btn">Save Changes</button>
+    </div>
+  </form>
+{% endblock %}

--- a/templates/property_list.html
+++ b/templates/property_list.html
@@ -10,6 +10,7 @@
         <th>Value</th>
         <th>Type</th>
         <th>Address</th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody>
@@ -20,10 +21,16 @@
         <td>£{{ '{:,.2f}'.format(property.value) }}</td>
         <td>{{ property.type.value }}</td>
         <td>{{ property.address }}</td>
+        <td>
+          <a href="/properties/{{ property.id }}/edit" class="btn">Edit</a>
+          <form action="/properties/{{ property.id }}/delete" method="post" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete property?');">
+            <button type="submit" class="btn btn-secondary">Delete</button>
+          </form>
+        </td>
       </tr>
       {% else %}
       <tr>
-        <td colspan="5" class="no-data">No properties added yet.</td>
+        <td colspan="6" class="no-data">No properties added yet.</td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
## Summary
- allow editing and deleting properties via new CRUD helpers and routes
- add property edit page with form pre-populated from database
- show edit and delete buttons on property list with confirmation prompt

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689f407545ec8330b7dda3162e1e2042