### PR TITLE
Fix rent percentage layout on add property form

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -185,6 +185,11 @@ body {
   flex-direction: column;
 }
 
+.dual-input {
+  display: flex;
+  gap: 1rem;
+}
+
 .form-group label {
   margin-bottom: 0.5rem;
   font-weight: 500;

--- a/templates/add_property.html
+++ b/templates/add_property.html
@@ -67,20 +67,22 @@
           <option value="percent">%</option>
         </select>
       </div>
-      <div class="form-group" id="rent_percent_group" style="display: none;">
-        <label for="monthly_rent_percent">Monthly rent (%)</label>
-        <input type="number" id="monthly_rent_percent" step="0.01" min="0" />
-      </div>
-      <div class="form-group">
-        <label for="monthly_rent">Monthly rent (£)</label>
-        <input
-          type="number"
-          id="monthly_rent"
-          name="monthly_rent"
-          step="0.01"
-          min="0"
-          required
-        />
+      <div id="rent_container" class="dual-input">
+        <div class="form-group" id="rent_percent_group" style="display: none; flex: 1;">
+          <label for="monthly_rent_percent">Monthly rent (%)</label>
+          <input type="number" id="monthly_rent_percent" step="0.01" min="0" />
+        </div>
+        <div class="form-group" style="flex: 1;">
+          <label for="monthly_rent">Monthly rent (£)</label>
+          <input
+            type="number"
+            id="monthly_rent"
+            name="monthly_rent"
+            step="0.01"
+            min="0"
+            required
+          />
+        </div>
       </div>
       <div class="form-group">
         <label for="indexation_type">Indexation type</label>


### PR DESCRIPTION
## Summary
- avoid duplicated fields on add property form and keep sections within three collapsible groups
- add side-by-side inputs for rent percentage and value

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f440c1a048330916856d30180f35b