### PR TITLE
Align edit property page with add property inputs

### DIFF
--- a/templates/edit_property.html
+++ b/templates/edit_property.html
@@ -2,29 +2,391 @@
 {% block title %}Edit Property – Property Planner{% endblock %}
 {% block content %}
   <h1 class="page-title">Edit Property</h1>
-  <form method="post" class="form">
-    <div class="form-group">
-      <label for="name">Name</label>
-      <input type="text" id="name" name="name" value="{{ property.name }}" required />
-    </div>
-    <div class="form-group">
-      <label for="value">Value (£)</label>
-      <input type="number" id="value" name="value" step="0.01" min="0" value="{{ property.value }}" required />
-    </div>
-    <div class="form-group">
-      <label for="type">Type</label>
-      <select id="type" name="type" required>
-        <option value="personal" {% if property.type.value == 'personal' %}selected{% endif %}>Personal</option>
-        <option value="company" {% if property.type.value == 'company' %}selected{% endif %}>Company</option>
-      </select>
-    </div>
-    <div class="form-group">
-      <label for="address">Address</label>
-      <input type="text" id="address" name="address" value="{{ property.address }}" />
-    </div>
+  <form method="post" class="form" id="property_form">
+
+    <details class="form-section" open>
+      <summary>Property Details</summary>
+      <div class="form-group">
+        <label for="postcode">Postcode</label>
+        <input
+          type="text"
+          id="postcode"
+          name="postcode"
+          placeholder="Enter postcode"
+          value="{{ property.postcode }}"
+          required
+        />
+      </div>
+      <div class="form-group">
+        <label for="address">Address</label>
+        <select id="address" name="address" required>
+          <option value="">Select an address</option>
+          {% if property.address %}
+          <option value="{{ property.address }}" selected>{{ property.address }}</option>
+          {% endif %}
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="name">Name</label>
+        <input type="text" id="name" name="name" value="{{ property.name }}" required />
+      </div>
+      <div class="form-group">
+        <label for="purchase_price">Purchase price (£)</label>
+        <input
+          type="number"
+          id="purchase_price"
+          name="value"
+          step="0.01"
+          min="0"
+          value="{{ property.value }}"
+          required
+        />
+      </div>
+      <div class="form-group">
+        <label for="acquisition_date">Acquisition date</label>
+        <input type="date" id="acquisition_date" name="acquisition_date" value="{{ property.acquisition_date }}" required />
+      </div>
+      <div class="form-group">
+        <label for="type">Type</label>
+        <select id="type" name="type" required>
+          <option value="personal" {% if property.type.value == 'personal' %}selected{% endif %}>Personal</option>
+          <option value="company" {% if property.type.value == 'company' %}selected{% endif %}>Company</option>
+        </select>
+      </div>
+    </details>
+
+    <details class="form-section">
+      <summary>Lease Details</summary>
+      <div class="form-group">
+        <label for="lease_type">Lease type</label>
+        <select id="lease_type" name="lease_type" required>
+          <option value="council_20" {% if property.lease_type == 'council_20' %}selected{% endif %}>Council 20 Year</option>
+          <option value="council_7" {% if property.lease_type == 'council_7' %}selected{% endif %}>Council 7 Year</option>
+          <option value="ast" {% if property.lease_type == 'ast' %}selected{% endif %}>AST</option>
+          <option value="hmo" {% if property.lease_type == 'hmo' %}selected{% endif %}>HMO</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="rent_input_type">Rent input</label>
+        <select id="rent_input_type">
+          <option value="currency" {% if property.rent_input_type != 'percent' %}selected{% endif %}>£</option>
+          <option value="percent" {% if property.rent_input_type == 'percent' %}selected{% endif %}>%</option>
+        </select>
+      </div>
+      <div id="rent_percent_container" style="display: none; gap: 1rem;">
+        <div class="form-group" style="flex: 1;">
+          <label for="yearly_rent_percent">Yearly rent (% of PV)</label>
+          <input type="number" id="yearly_rent_percent" step="0.01" min="0" value="{{ property.yearly_rent_percent }}" disabled />
+        </div>
+        <div class="form-group" style="flex: 1;">
+          <label for="monthly_rent_calculated">Monthly rent (yearly / 12)</label>
+          <input
+            type="number"
+            id="monthly_rent_calculated"
+            name="monthly_rent"
+            step="0.01"
+            min="0"
+            value="{{ property.monthly_rent if property.rent_input_type == 'percent' else '' }}"
+            readonly
+            disabled
+            required
+          />
+        </div>
+      </div>
+      <div class="form-group" id="monthly_rent_currency_group">
+        <label for="monthly_rent_currency">Monthly rent (£)</label>
+        <input
+          type="number"
+          id="monthly_rent_currency"
+          name="monthly_rent"
+          step="0.01"
+          min="0"
+          value="{{ property.monthly_rent if property.rent_input_type != 'percent' else '' }}"
+          required
+        />
+      </div>
+      <div class="form-group">
+        <label for="indexation_type">Indexation type</label>
+        <select id="indexation_type" name="indexation_type">
+          <option value="none" {% if property.indexation_type == 'none' %}selected{% endif %}>None</option>
+          <option value="fixed" {% if property.indexation_type == 'fixed' %}selected{% endif %}>Fixed</option>
+          <option value="cpi" {% if property.indexation_type == 'cpi' %}selected{% endif %}>CPI</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="indexation_rate">Indexation rate (%)</label>
+        <input type="number" id="indexation_rate" name="indexation_rate" step="0.01" min="0" value="{{ property.indexation_rate }}" />
+      </div>
+      <div class="form-group">
+        <label for="lease_start">Lease start date</label>
+        <input type="date" id="lease_start" name="lease_start" value="{{ property.lease_start }}" />
+      </div>
+      <div class="form-group">
+        <label for="lease_end">Lease end date</label>
+        <input type="date" id="lease_end" name="lease_end" value="{{ property.lease_end }}" />
+      </div>
+    </details>
+
+    <details class="form-section">
+      <summary>Mortgage Details</summary>
+      <div class="form-group">
+        <label for="has_mortgage">Has mortgage?</label>
+        <select id="has_mortgage" name="has_mortgage">
+          <option value="no" {% if not property.has_mortgage %}selected{% endif %}>No</option>
+          <option value="yes" {% if property.has_mortgage %}selected{% endif %}>Yes</option>
+        </select>
+      </div>
+      <div id="mortgage_fields" style="display: none; gap: 1rem;">
+        <div class="form-group">
+          <label for="lender_name">Lender name</label>
+          <input type="text" id="lender_name" name="lender_name" value="{{ property.lender_name }}" />
+        </div>
+        <div class="form-group">
+          <label for="loan_amount">Loan amount (£)</label>
+          <input type="number" id="loan_amount" name="loan_amount" step="0.01" min="0" value="{{ property.loan_amount }}" />
+        </div>
+        <div class="form-group">
+          <label for="interest_rate">Interest rate (%)</label>
+          <input type="number" id="interest_rate" name="interest_rate" step="0.01" min="0" value="{{ property.interest_rate }}" />
+        </div>
+        <div class="form-group">
+          <label for="repayment_type">Repayment type</label>
+          <select id="repayment_type" name="repayment_type">
+            <option value="interest_only" {% if property.repayment_type == 'interest_only' %}selected{% endif %}>Interest-only</option>
+            <option value="repayment" {% if property.repayment_type == 'repayment' %}selected{% endif %}>Repayment</option>
+          </select>
+        </div>
+        <div class="form-group">
+          <label for="mortgage_term">Term (years)</label>
+          <input type="number" id="mortgage_term" name="mortgage_term" min="0" value="{{ property.mortgage_term }}" />
+        </div>
+      </div>
+    </details>
+
     <div class="form-actions">
       <a href="/properties" class="btn btn-secondary">Cancel</a>
       <button type="submit" class="btn">Save Changes</button>
     </div>
   </form>
+  <script>
+    const GET_ADDRESS_API_KEY = "MR3OmMfdukGPgl0gW_Ztxw44533"; // Replace with your API key
+    const addressSelect = document.getElementById("address");
+    const nameInput = document.getElementById("name");
+    const rentInputType = document.getElementById("rent_input_type");
+    const rentPercentContainer = document.getElementById("rent_percent_container");
+    const rentPercentInput = document.getElementById("yearly_rent_percent");
+    const monthlyRentCalculatedInput = document.getElementById(
+      "monthly_rent_calculated"
+    );
+    const monthlyRentCurrencyGroup = document.getElementById(
+      "monthly_rent_currency_group"
+    );
+    const monthlyRentCurrencyInput = document.getElementById(
+      "monthly_rent_currency"
+    );
+    const propertyValueInput = document.getElementById("purchase_price");
+    const leaseTypeSelect = document.getElementById("lease_type");
+    const leaseStartInput = document.getElementById("lease_start");
+    const leaseEndInput = document.getElementById("lease_end");
+    const hasMortgageSelect = document.getElementById("has_mortgage");
+    const mortgageFields = document.getElementById("mortgage_fields");
+    const lenderInput = document.getElementById("lender_name");
+    const loanAmountInput = document.getElementById("loan_amount");
+    const interestRateInput = document.getElementById("interest_rate");
+    const repaymentTypeSelect = document.getElementById("repayment_type");
+    const mortgageTermInput = document.getElementById("mortgage_term");
+    const propertyId = {{ property.id }};
+
+    document.getElementById("postcode").addEventListener("change", async function () {
+      const postcode = this.value.trim();
+      addressSelect.innerHTML = '<option value="">Loading...</option>';
+      if (!postcode) {
+        addressSelect.innerHTML = '<option value="">Select an address</option>';
+        return;
+      }
+      try {
+        const response = await fetch(
+          `https://api.getAddress.io/find/${encodeURIComponent(postcode)}?api-key=${GET_ADDRESS_API_KEY}`
+        );
+        if (!response.ok) {
+          throw new Error("Lookup failed");
+        }
+        const data = await response.json();
+        addressSelect.innerHTML = "";
+        data.addresses.forEach((addr) => {
+          const cleanedAddr = addr
+            .split(",")
+            .map((part) => part.trim())
+            .filter((part) => part)
+            .join(", ");
+          const option = document.createElement("option");
+          option.value = cleanedAddr;
+          option.textContent = cleanedAddr;
+          addressSelect.appendChild(option);
+        });
+      } catch (err) {
+        addressSelect.innerHTML = '<option value="">No addresses found</option>';
+      }
+    });
+
+    addressSelect.addEventListener("change", () => {
+      const selected = addressSelect.value;
+      const firstPart = selected.split(",")[0].trim();
+      nameInput.value = firstPart;
+    });
+
+    rentInputType.addEventListener("change", () => {
+      if (rentInputType.value === "percent") {
+        rentPercentContainer.style.display = "flex";
+        rentPercentInput.disabled = false;
+        monthlyRentCalculatedInput.disabled = false;
+        monthlyRentCalculatedInput.value = "";
+        monthlyRentCurrencyGroup.style.display = "none";
+        monthlyRentCurrencyInput.disabled = true;
+      } else {
+        rentPercentContainer.style.display = "none";
+        rentPercentInput.disabled = true;
+        monthlyRentCalculatedInput.disabled = true;
+        monthlyRentCurrencyGroup.style.display = "flex";
+        monthlyRentCurrencyInput.disabled = false;
+      }
+    });
+
+    function updateMonthlyRent() {
+      const value = parseFloat(propertyValueInput.value);
+      const percent = parseFloat(rentPercentInput.value);
+      if (!isNaN(value) && !isNaN(percent)) {
+        const yearlyRent = value * (percent / 100);
+        monthlyRentCalculatedInput.value = (yearlyRent / 12).toFixed(2);
+      } else {
+        monthlyRentCalculatedInput.value = "";
+      }
+    }
+
+    rentPercentInput.addEventListener("input", updateMonthlyRent);
+    propertyValueInput.addEventListener("input", () => {
+      if (rentInputType.value === "percent") updateMonthlyRent();
+    });
+
+    function updateLeaseEnd() {
+      const startDate = new Date(leaseStartInput.value);
+      if (isNaN(startDate)) {
+        leaseEndInput.value = "";
+        return;
+      }
+      let years = 0;
+      if (leaseTypeSelect.value === "council_20") years = 20;
+      else if (leaseTypeSelect.value === "council_7") years = 7;
+      if (years > 0) {
+        const endDate = new Date(startDate);
+        endDate.setFullYear(endDate.getFullYear() + years);
+        leaseEndInput.value = endDate.toISOString().split("T")[0];
+      }
+    }
+
+    leaseTypeSelect.addEventListener("change", updateLeaseEnd);
+    leaseStartInput.addEventListener("change", updateLeaseEnd);
+
+    hasMortgageSelect.addEventListener("change", () => {
+      const hasMortgage = hasMortgageSelect.value === "yes";
+      mortgageFields.style.display = hasMortgage ? "grid" : "none";
+      [
+        lenderInput,
+        loanAmountInput,
+        interestRateInput,
+        repaymentTypeSelect,
+        mortgageTermInput,
+      ].forEach((el) => {
+        if (hasMortgage) el.setAttribute("required", "required");
+        else el.removeAttribute("required");
+      });
+    });
+
+    rentInputType.dispatchEvent(new Event("change"));
+    leaseTypeSelect.dispatchEvent(new Event("change"));
+    hasMortgageSelect.dispatchEvent(new Event("change"));
+
+    document.getElementById("property_form").addEventListener("submit", async (e) => {
+      e.preventDefault();
+
+      const postcode = document.getElementById("postcode").value.trim();
+      const address = addressSelect.value;
+      const purchasePrice = parseFloat(propertyValueInput.value);
+      const acquisitionDate = document
+        .getElementById("acquisition_date")
+        .value;
+      const leaseType = leaseTypeSelect.value;
+      const monthlyRent = parseFloat(
+        rentInputType.value === "percent"
+          ? monthlyRentCalculatedInput.value
+          : monthlyRentCurrencyInput.value
+      );
+      const hasMortgage = hasMortgageSelect.value === "yes";
+
+      // Basic validation for required numeric fields
+      if (
+        !postcode ||
+        !address ||
+        !acquisitionDate ||
+        !leaseType ||
+        isNaN(purchasePrice) ||
+        purchasePrice <= 0 ||
+        isNaN(monthlyRent) ||
+        monthlyRent <= 0
+      ) {
+        alert("Please complete all required fields with valid values.");
+        return;
+      }
+
+      if (
+        hasMortgage &&
+        (isNaN(parseFloat(loanAmountInput.value)) ||
+          parseFloat(loanAmountInput.value) <= 0 ||
+          isNaN(parseFloat(interestRateInput.value)) ||
+          parseFloat(interestRateInput.value) <= 0 ||
+          isNaN(parseFloat(mortgageTermInput.value)) ||
+          parseFloat(mortgageTermInput.value) <= 0)
+      ) {
+        alert("Please provide positive numbers for mortgage details.");
+        return;
+      }
+
+      const payload = {
+        postcode,
+        address,
+        name: nameInput.value,
+        value: purchasePrice,
+        acquisition_date: acquisitionDate,
+        type: document.getElementById("type").value,
+        lease_type: leaseType,
+        monthly_rent: monthlyRent,
+        has_mortgage: hasMortgage,
+        lender_name: hasMortgage ? lenderInput.value : null,
+        loan_amount: hasMortgage ? parseFloat(loanAmountInput.value) || null : null,
+        interest_rate: hasMortgage
+          ? parseFloat(interestRateInput.value) || null
+          : null,
+        repayment_type: hasMortgage ? repaymentTypeSelect.value : null,
+        mortgage_term: hasMortgage
+          ? parseFloat(mortgageTermInput.value) || null
+          : null,
+      };
+
+      try {
+        const response = await fetch(`/api/properties/${propertyId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (response.ok) {
+          alert("Property updated successfully!");
+          window.location.href = "/properties";
+        } else {
+          alert("Failed to update property.");
+        }
+      } catch (err) {
+        alert("Error updating property.");
+      }
+    });
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Mirror add-property fields on the edit-property page, including property, lease, and mortgage sections
- Prefill existing values and post updates via `/api/properties/{id}` for consistency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f53c3ddd88330ad86abcfbac1b740