### PR TITLE
Add property details page and view action

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -83,6 +83,17 @@ def add_property(
     return RedirectResponse(url="/properties", status_code=303)
 
 
+@app.get("/properties/{property_id}", response_class=HTMLResponse)
+def view_property(property_id: int, request: Request, db: Session = Depends(get_db)):
+    """Display a single property's details."""
+    property_obj = crud.get_property(db, property_id)
+    if not property_obj:
+        return RedirectResponse(url="/properties", status_code=303)
+    return templates.TemplateResponse(
+        "view_property.html", {"request": request, "property": property_obj}
+    )
+
+
 @app.get("/properties/{property_id}/edit", response_class=HTMLResponse)
 def edit_property_form(property_id: int, request: Request, db: Session = Depends(get_db)):
     """Render a form pre-populated with an existing property's data."""

--- a/templates/property_list.html
+++ b/templates/property_list.html
@@ -10,7 +10,7 @@
         <th>Value</th>
         <th>Type</th>
         <th>Address</th>
-        <th>Actions</th>
+        <th>View</th>
       </tr>
     </thead>
     <tbody>
@@ -22,10 +22,7 @@
         <td>{{ property.type.value }}</td>
         <td>{{ property.address }}</td>
         <td>
-          <a href="/properties/{{ property.id }}/edit" class="btn">Edit</a>
-          <form action="/properties/{{ property.id }}/delete" method="post" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete property?');">
-            <button type="submit" class="btn btn-secondary">Delete</button>
-          </form>
+          <a href="/properties/{{ property.id }}" class="btn">View</a>
         </td>
       </tr>
       {% else %}

--- a/templates/view_property.html
+++ b/templates/view_property.html
@@ -1,0 +1,44 @@
+{% extends "layout.html" %}
+{% block title %}{{ property.name }} – Property Planner{% endblock %}
+{% block content %}
+  <h1 class="page-title">{{ property.name }}</h1>
+
+  <details class="form-section" open>
+    <summary>Property Details</summary>
+    <p><strong>ID:</strong> {{ property.id }}</p>
+    <p><strong>Value:</strong> £{{ '{:,.2f}'.format(property.value) }}</p>
+    <p><strong>Type:</strong> {{ property.type.value }}</p>
+    <p><strong>Address:</strong> {{ property.address }}</p>
+  </details>
+
+  <details class="form-section">
+    <summary>Lease Details</summary>
+    {% if property.lease_type is defined %}
+      <p><strong>Lease Type:</strong> {{ property.lease_type }}</p>
+      {% if property.lease_start is defined %}<p><strong>Lease Start:</strong> {{ property.lease_start }}</p>{% endif %}
+      {% if property.lease_end is defined %}<p><strong>Lease End:</strong> {{ property.lease_end }}</p>{% endif %}
+    {% else %}
+      <p>No lease details available.</p>
+    {% endif %}
+  </details>
+
+  <details class="form-section">
+    <summary>Mortgage Details</summary>
+    {% if property.has_mortgage is defined and property.has_mortgage %}
+      {% if property.lender_name is defined %}<p><strong>Lender:</strong> {{ property.lender_name }}</p>{% endif %}
+      {% if property.loan_amount is defined %}<p><strong>Loan Amount:</strong> £{{ '{:,.2f}'.format(property.loan_amount) }}</p>{% endif %}
+      {% if property.interest_rate is defined %}<p><strong>Interest Rate:</strong> {{ property.interest_rate }}%</p>{% endif %}
+      {% if property.repayment_type is defined %}<p><strong>Repayment Type:</strong> {{ property.repayment_type }}</p>{% endif %}
+      {% if property.mortgage_term is defined %}<p><strong>Term:</strong> {{ property.mortgage_term }}</p>{% endif %}
+    {% else %}
+      <p>No mortgage details available.</p>
+    {% endif %}
+  </details>
+
+  <div class="form-actions">
+    <a href="/properties/{{ property.id }}/edit" class="btn">Edit</a>
+    <form action="/properties/{{ property.id }}/delete" method="post" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete property?');">
+      <button type="submit" class="btn btn-secondary">Delete</button>
+    </form>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- allow viewing a single property's details via new `/properties/{id}` route
- replace edit/delete links with a view button on the property list
- new template shows property info plus placeholder lease and mortgage sections with edit/delete actions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f57bbe4788330bec169b5a9889b0f