### PR TITLE
Add KPI strip with income toggle to dashboard

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -50,8 +50,14 @@ def delete_property(db: Session, property_id: int):
     return db_property
 
 
-def portfolio_summary(db: Session):
-    """Compute summary statistics for the dashboard."""
+def portfolio_summary(db: Session, period: str = "month"):
+    """Compute summary statistics for the dashboard.
+
+    Currently only property counts and company portfolio value are persisted.
+    Other metrics such as personal portfolio value, company cash and income are
+    placeholders until the relevant data models are implemented.
+    """
+
     personal_count = (
         db.query(models.Property)
         .filter(models.Property.type == models.PropertyType.personal)
@@ -62,16 +68,20 @@ def portfolio_summary(db: Session):
         .filter(models.Property.type == models.PropertyType.company)
         .count()
     )
-    total_value = db.query(func.sum(models.Property.value)).scalar() or 0.0
     company_value = (
         db.query(func.sum(models.Property.value))
         .filter(models.Property.type == models.PropertyType.company)
         .scalar()
         or 0.0
     )
+
     return {
+        "personal_portfolio_value": 0.0,
+        "company_value": company_value,
+        "company_cash": 0.0,
         "personal_count": personal_count,
         "company_count": company_count,
-        "total_value": total_value,
-        "company_value": company_value,
+        "gross_income": 0.0,
+        "net_income": 0.0,
+        "period": period,
     }

--- a/app/main.py
+++ b/app/main.py
@@ -31,19 +31,12 @@ def get_db():
 
 
 @app.get("/", response_class=HTMLResponse)
-def read_dashboard(request: Request, db: Session = Depends(get_db)):
+def read_dashboard(
+    request: Request, period: str = "month", db: Session = Depends(get_db)
+):
     """Render the dashboard with portfolio summary statistics."""
-    summary = crud.portfolio_summary(db)
-    return templates.TemplateResponse(
-        "dashboard.html",
-        {
-            "request": request,
-            "personal_count": summary["personal_count"],
-            "company_count": summary["company_count"],
-            "total_value": summary["total_value"],
-            "company_value": summary["company_value"],
-        },
-    )
+    summary = crud.portfolio_summary(db, period=period)
+    return templates.TemplateResponse("dashboard.html", {"request": request, **summary})
 
 
 @app.get("/properties", response_class=HTMLResponse)

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -228,3 +228,49 @@ body {
 .btn:hover {
   background-color: #3c5ecb;
 }
+
+/* Empty state text used within cards */
+.empty-state {
+  color: #7f8c8d;
+  font-size: 1rem;
+}
+
+/* Simple loading skeleton for KPI cards */
+.skeleton {
+  background: linear-gradient(90deg, #eee, #ddd, #eee);
+  background-size: 200% 100%;
+  animation: skeleton-loading 1.5s infinite;
+  color: transparent;
+  border-radius: 4px;
+}
+
+@keyframes skeleton-loading {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+/* Toggle buttons for monthly/yearly income */
+.toggle {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.toggle button {
+  padding: 0.25rem 0.75rem;
+  border: 1px solid #d1d9e6;
+  background-color: #ffffff;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.toggle button.active {
+  background-color: #4e73df;
+  color: #ffffff;
+  border-color: #4e73df;
+}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -4,20 +4,60 @@
   <h1 class="page-title">Dashboard</h1>
   <div class="dashboard-cards">
     <div class="card">
-      <h2>Personal Properties</h2>
-      <p class="value">{{ personal_count }}</p>
-    </div>
-    <div class="card">
-      <h2>Company Properties</h2>
-      <p class="value">{{ company_count }}</p>
-    </div>
-    <div class="card">
-      <h2>Total Portfolio Value</h2>
-      <p class="value">£{{ '{:,.2f}'.format(total_value) }}</p>
+      <h2>Personal Portfolio Value</h2>
+      <p class="value skeleton" data-value="£0.00"></p>
     </div>
     <div class="card">
       <h2>Company Portfolio Value</h2>
-      <p class="value">£{{ '{:,.2f}'.format(company_value) }}</p>
+      {% if company_value %}
+        <p class="value skeleton" data-value="£{{ '{:,.2f}'.format(company_value) }}"></p>
+      {% else %}
+        <p class="value empty-state">No data</p>
+      {% endif %}
+    </div>
+    <div class="card">
+      <h2>Company Cash</h2>
+      {% if company_cash %}
+        <p class="value skeleton" data-value="£{{ '{:,.2f}'.format(company_cash) }}"></p>
+      {% else %}
+        <p class="value empty-state">No data</p>
+      {% endif %}
+    </div>
+    <div class="card">
+      <h2>Properties — Personal</h2>
+      {% if personal_count %}
+        <p class="value skeleton" data-value="{{ personal_count }}"></p>
+      {% else %}
+        <p class="value empty-state">No properties</p>
+      {% endif %}
+    </div>
+    <div class="card">
+      <h2>Properties — Company</h2>
+      {% if company_count %}
+        <p class="value skeleton" data-value="{{ company_count }}"></p>
+      {% else %}
+        <p class="value empty-state">No properties</p>
+      {% endif %}
+    </div>
+    <div class="card">
+      <h2>Gross / Net Income</h2>
+      <div class="toggle">
+        <button class="{% if period == 'month' %}active{% endif %}" onclick="location.href='/?period=month'">Month</button>
+        <button class="{% if period == 'year' %}active{% endif %}" onclick="location.href='/?period=year'">Year</button>
+      </div>
+      {% if gross_income or net_income %}
+        <p class="value skeleton" data-value="£{{ '{:,.2f}'.format(gross_income) }} / £{{ '{:,.2f}'.format(net_income) }}"></p>
+      {% else %}
+        <p class="value empty-state">No data</p>
+      {% endif %}
     </div>
   </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('.value.skeleton').forEach(el => {
+        el.textContent = el.dataset.value;
+        el.classList.remove('skeleton');
+      });
+    });
+  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Extend dashboard data to include placeholders for cash, income and personal portfolio value and return selected period.
- Replace dashboard UI with six-card KPI strip and month/year income toggle using skeleton and empty state styles.
- Add CSS for toggle controls and loading skeletons.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5e599970833094a943fa4f983735