### PR TITLE
Add mock stats and cashflow endpoints for dashboard

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
 
 from . import models, database, crud, schemas
-from .routers import refinancing, acquisition
+from .routers import refinancing, acquisition, stats
 
 
 # Create database tables on startup if they don't already exist.
@@ -130,5 +130,6 @@ def create_property_api(property_in: schemas.PropertyCreate, db: Session = Depen
     return crud.create_property(db, property_in)
 
 # Include placeholder routers for future functionality.
+app.include_router(stats.router)
 app.include_router(refinancing.router)
 app.include_router(acquisition.router)

--- a/app/routers/stats.py
+++ b/app/routers/stats.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Query
+from typing import List, Dict
+
+router = APIRouter()
+
+
+@router.get("/cashflow/monthly")
+def cashflow_monthly(
+    company_id: int,
+    from_: str = Query(..., alias="from"),
+    to: str = Query(..., alias="to"),
+) -> List[Dict[str, float]]:
+    """Return mocked monthly cashflow data."""
+    return [
+        {"month": from_, "cash_in": 0.0, "cash_out": 0.0, "net": 0.0},
+        {"month": to, "cash_in": 0.0, "cash_out": 0.0, "net": 0.0},
+    ]
+
+
+@router.get("/properties/stats")
+def properties_stats(company_id: int) -> Dict[str, float]:
+    """Return mocked statistics about company and personal properties."""
+    return {
+        "company_count": 0,
+        "personal_count": 0,
+        "company_portfolio_value": 0.0,
+        "personal_portfolio_value": 0.0,
+        "company_cash": 0.0,
+    }

--- a/tests/test_stats_api.py
+++ b/tests/test_stats_api.py
@@ -1,0 +1,30 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_properties_stats():
+    response = client.get("/properties/stats", params={"company_id": 1})
+    assert response.status_code == 200
+    data = response.json()
+    assert set(data.keys()) == {
+        "company_count",
+        "personal_count",
+        "company_portfolio_value",
+        "personal_portfolio_value",
+        "company_cash",
+    }
+
+
+def test_cashflow_monthly():
+    response = client.get(
+        "/cashflow/monthly",
+        params={"company_id": 1, "from": "2024-01", "to": "2024-02"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert data[0]["month"] == "2024-01"
+    assert data[1]["month"] == "2024-02"


### PR DESCRIPTION
## Summary
- add mock `/cashflow/monthly` and `/properties/stats` GET endpoints
- wire new stats router into FastAPI app
- cover endpoints with minimal tests

## Testing
- `pytest -q` *(fails: httpx missing and install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_689f691fb7348330a5885af94a1a5f9d