### PR TITLE
Add Refi Ready dashboard card

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -126,6 +126,14 @@ body {
   border-bottom: 1px solid #e5e9f2;
 }
 
+.property-table tbody tr {
+  cursor: pointer;
+}
+
+.property-table tbody tr:hover {
+  background-color: #f0f2f5;
+}
+
 .no-data {
   text-align: center;
   padding: 2rem 0;

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -51,6 +51,22 @@
         <p class="value empty-state">No data</p>
       {% endif %}
     </div>
+    <div class="card">
+      <h2>Refi Ready</h2>
+      <table class="property-table">
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>LTV</th>
+            <th>DSCR</th>
+            <th>Est. Cash-Out</th>
+          </tr>
+        </thead>
+        <tbody id="refi-table-body">
+          <tr><td colspan="4" class="no-data">Loading...</td></tr>
+        </tbody>
+      </table>
+    </div>
   </div>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
@@ -58,6 +74,34 @@
         el.textContent = el.dataset.value;
         el.classList.remove('skeleton');
       });
+
+      fetch('/refi/eligibility?company_id=1&limit=5&sort=-cash_out')
+        .then(response => response.json())
+        .then(data => {
+          const tbody = document.getElementById('refi-table-body');
+          if (!data || data.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="4" class="no-data">No properties</td></tr>';
+            return;
+          }
+          tbody.innerHTML = '';
+          data.forEach(item => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `\
+              <td>${item.address}</td>
+              <td>${(item.ltv * 100).toFixed(0)}%</td>
+              <td>${Number(item.dscr).toFixed(2)}</td>
+              <td>£${Number(item.cash_out).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+            `;
+            tr.addEventListener('click', () => {
+              window.location.href = '/properties/' + item.id;
+            });
+            tbody.appendChild(tr);
+          });
+        })
+        .catch(() => {
+          const tbody = document.getElementById('refi-table-body');
+          tbody.innerHTML = '<tr><td colspan="4" class="no-data">Failed to load</td></tr>';
+        });
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add Refi Ready card to dashboard that loads top cash-out properties
- fetch /refi/eligibility and navigate to property detail on row click
- style property table rows for clickability

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_689f6e1c788c8330b32d222145530556