### PR TITLE
Fix stats API validation and update DB schema for postcode

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -24,6 +24,7 @@ def init_db():
         column["name"] for column in inspector.get_columns("properties")
     }
     required_columns = {
+        "postcode",
         "lease_type",
         "rent_input_type",
         "yearly_rent_percent",
@@ -44,6 +45,7 @@ def init_db():
         with engine.begin() as conn:
             for column in missing:
                 if column in {
+                    "postcode",
                     "lease_type",
                     "rent_input_type",
                     "indexation_type",

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,9 @@ templates = Jinja2Templates(directory="templates")
 # Serve static files (CSS, JS, images) from the 'static' directory.
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
+# Include stats router before property routes to avoid path conflicts.
+app.include_router(stats.router)
+
 
 def get_db():
     """Provide a SQLAlchemy database session to path operations."""
@@ -116,6 +119,5 @@ def create_property_api(property_in: schemas.PropertyCreate, db: Session = Depen
     return crud.create_property(db, property_in)
 
 # Include placeholder routers for future functionality.
-app.include_router(stats.router)
 app.include_router(refinancing.router)
 app.include_router(acquisition.router)

--- a/app/routers/stats.py
+++ b/app/routers/stats.py
@@ -1,29 +1,45 @@
 from fastapi import APIRouter, Query
-from typing import List, Dict
+from typing import List
+from pydantic import BaseModel
 
 router = APIRouter()
 
 
-@router.get("/cashflow/monthly")
+class CashflowEntry(BaseModel):
+    month: str
+    cash_in: float
+    cash_out: float
+    net: float
+
+
+class PropertyStats(BaseModel):
+    company_count: int
+    personal_count: int
+    company_portfolio_value: float
+    personal_portfolio_value: float
+    company_cash: float
+
+
+@router.get("/cashflow/monthly", response_model=List[CashflowEntry])
 def cashflow_monthly(
     company_id: int,
     from_: str = Query(..., alias="from"),
     to: str = Query(..., alias="to"),
-) -> List[Dict[str, float]]:
+) -> List[CashflowEntry]:
     """Return mocked monthly cashflow data."""
     return [
-        {"month": from_, "cash_in": 0.0, "cash_out": 0.0, "net": 0.0},
-        {"month": to, "cash_in": 0.0, "cash_out": 0.0, "net": 0.0},
+        CashflowEntry(month=from_, cash_in=0.0, cash_out=0.0, net=0.0),
+        CashflowEntry(month=to, cash_in=0.0, cash_out=0.0, net=0.0),
     ]
 
 
-@router.get("/properties/stats")
-def properties_stats(company_id: int) -> Dict[str, float]:
+@router.get("/properties/stats", response_model=PropertyStats)
+def properties_stats(company_id: int) -> PropertyStats:
     """Return mocked statistics about company and personal properties."""
-    return {
-        "company_count": 0,
-        "personal_count": 0,
-        "company_portfolio_value": 0.0,
-        "personal_portfolio_value": 0.0,
-        "company_cash": 0.0,
-    }
+    return PropertyStats(
+        company_count=0,
+        personal_count=0,
+        company_portfolio_value=0.0,
+        personal_portfolio_value=0.0,
+        company_cash=0.0,
+    )


### PR DESCRIPTION
## Summary
- add postcode column to database schema upgrades
- register stats API before property routes to avoid path conflicts
- type stats endpoints with Pydantic models for valid responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f72e11fd083309e17463494fbfa96