### PR TITLE
Fix property count queries to avoid missing-column errors

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -52,14 +52,16 @@ def portfolio_summary(db: Session, period: str = "month"):
     """
 
     personal_count = (
-        db.query(models.Property)
+        db.query(func.count(models.Property.id))
         .filter(models.Property.type == models.PropertyType.personal)
-        .count()
+        .scalar()
+        or 0
     )
     company_count = (
-        db.query(models.Property)
+        db.query(func.count(models.Property.id))
         .filter(models.Property.type == models.PropertyType.company)
-        .count()
+        .scalar()
+        or 0
     )
     company_value = (
         db.query(func.sum(models.Property.value))


### PR DESCRIPTION
## Summary
- use explicit COUNT when calculating portfolio totals to avoid selecting non-existent columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f7d1b513c832cb4497292bfd4ff81