### PR TITLE
Add collapsible property cards

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -198,6 +198,49 @@ body {
   gap: 1rem;
 }
 
+/* Property cards */
+.property-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.property-card {
+  background-color: #ffffff;
+  border: 1px solid #d1d9e6;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.property-card summary {
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+}
+
+.property-card-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #2c3e50;
+}
+
+.property-card-subtitle {
+  margin: 0;
+  color: #7f8c8d;
+  font-size: 0.9rem;
+}
+
+.property-card-body {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.property-card .btn {
+  width: fit-content;
+}
+
 .form-group label {
   margin-bottom: 0.5rem;
   font-weight: 500;

--- a/templates/property_list.html
+++ b/templates/property_list.html
@@ -2,34 +2,23 @@
 {% block title %}Property List – Property Planner{% endblock %}
 {% block content %}
   <h1 class="page-title">Property List</h1>
-  <table class="property-table">
-    <thead>
-      <tr>
-        <th>ID</th>
-        <th>Name</th>
-        <th>Value</th>
-        <th>Type</th>
-        <th>Address</th>
-        <th>View</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for property in properties %}
-      <tr>
-        <td>{{ property.id }}</td>
-        <td>{{ property.name }}</td>
-        <td>£{{ '{:,.2f}'.format(property.value) }}</td>
-        <td>{{ property.type.value }}</td>
-        <td>{{ property.address }}</td>
-        <td>
-          <a href="/properties/{{ property.id }}" class="btn">View</a>
-        </td>
-      </tr>
-      {% else %}
-      <tr>
-        <td colspan="6" class="no-data">No properties added yet.</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+  <div class="property-grid">
+    {% for property in properties %}
+    <details class="property-card">
+      <summary>
+        <h2 class="property-card-title">{{ property.name }}</h2>
+        <p class="property-card-subtitle">{{ property.address }}</p>
+      </summary>
+      <div class="property-card-body">
+        <p><strong>ID:</strong> {{ property.id }}</p>
+        <p><strong>Value:</strong> £{{ '{:,.2f}'.format(property.value) }}</p>
+        <p><strong>Type:</strong> {{ property.type.value }}</p>
+        <p><strong>Address:</strong> {{ property.address }}</p>
+        <a href="/properties/{{ property.id }}" class="btn">View</a>
+      </div>
+    </details>
+    {% else %}
+    <p class="no-data">No properties added yet.</p>
+    {% endfor %}
+  </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show properties as collapsible cards summarised by name and address
- style new property card grid for tile layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3c9606bf88330b3e84921a224abd9